### PR TITLE
add igvmfile read/write to vmgstool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9317,6 +9317,7 @@ dependencies = [
  "uefi_specs",
  "vmgs",
  "vmgs_format",
+ "winapi",
 ]
 
 [[package]]

--- a/Guide/src/dev_guide/dev_tools/vmgstool.md
+++ b/Guide/src/dev_guide/dev_tools/vmgstool.md
@@ -63,6 +63,14 @@ variables without parsers:
 
 `vmgstool.exe uefi-nvram dump --filepath <vmgs file path> --keypath <key file path> --truncate`
 
+### Read DLL File to Write IGVMfile to VMGS
+
+Additionally, the VmgsTool contains a tool to read the IGVMfile from a DLL (passed in as a data file)
+and write it to VMGS FileId 8 (GUEST_FIRMWARE). To do this pass one of three resource codes
+(nonconfidential, snp, tdx) into the cmdline tool:
+
+`vmgstool.exe copy-igvmfile --filepath <vmgs file path> --keypath <key file path> --datapath <dll path> --resource-code <code>`
+
 ### Delete Boot Variables to Recover a VM that Fails to Boot
 
 A VM may fail to boot if the disk configuration changes and

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -39,6 +39,13 @@ serde_json = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 ucs2.workspace = true
 
+[target.'cfg(windows)'.dependencies.winapi]
+features = [
+  "libloaderapi",
+  "errhandlingapi",
+]
+workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 

--- a/vm/vmgs/vmgstool/build.rs
+++ b/vm/vmgs/vmgstool/build.rs
@@ -9,4 +9,5 @@ fn main() {
     if cfg!(feature = "encryption_ossl") || cfg!(feature = "encryption_win") {
         println!("cargo:rustc-cfg=with_encryption")
     }
+    println!("cargo:rustc-check-cfg=cfg(guest_arch, values(\"x86_64\"))");
 }

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 #![expect(missing_docs)]
-#![forbid(unsafe_code)]
+// UNSAFETY: Loading a dll is inheritently unsafe
+#![cfg_attr(all(windows, guest_arch = "x86_64"), expect(unsafe_code))]
 
 mod storage_backend;
 #[cfg(feature = "test_helpers")]
@@ -94,6 +95,9 @@ enum Error {
     GspUnknown,
     #[error("VMGS file is using an unknown encryption algorithm")]
     EncryptionUnknown,
+    #[cfg(all(windows, guest_arch = "x86_64"))]
+    #[error("Unable to read IGVM file with Error: {0}")]
+    UnableToReadIgvmFile(String),
 }
 
 impl From<vmgs::Error> for Error {
@@ -125,6 +129,17 @@ enum ExitCode {
     ErrorGspUnknown = 7,
 }
 
+#[derive(Debug, Clone, Copy)]
+#[repr(i32)]
+#[cfg(all(windows, guest_arch = "x86_64"))]
+enum ResourceCode {
+    NonConfidential = 13510,
+    Snp = 13515,
+    SnpNoHcl = 13516,
+    Tdx = 13520,
+    TdxNoHcl = 13521,
+}
+
 #[derive(Args)]
 struct FilePathArg {
     /// VMGS file path
@@ -154,6 +169,7 @@ enum Options {
     /// `keypath` and `encryptionalgorithm` must both be specified if encrypted
     /// guest state is required.
     Create {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
         /// VMGS file size, default = 4194816 (~4MB)
@@ -183,6 +199,7 @@ enum Options {
     ///
     /// The proper key file must be specified to write encrypted data.
     Write {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
         /// Data file path to read
@@ -202,6 +219,7 @@ enum Options {
     /// is encrypted and no key is specified, the data will be dumped without
     /// decrypting.
     Dump {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
         /// Data file path to write
@@ -217,11 +235,13 @@ enum Options {
     },
     /// Dump headers of the VMGS file at `filepath` to the console.
     DumpHeaders {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
     },
     /// Get the size of the specified `fileid` within the VMGS file
     QuerySize {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
         #[command(flatten)]
@@ -231,6 +251,7 @@ enum Options {
     ///
     /// Both key files must contain a key that is 32 bytes long.
     UpdateKey {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
         /// Current encryption key file path.
@@ -245,6 +266,7 @@ enum Options {
     },
     /// Encrypt an existing VMGS file
     Encrypt {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
         /// Encryption key file path. The file must contain a key that is 32 bytes long.
@@ -256,6 +278,7 @@ enum Options {
     },
     /// Query whether a VMGS file is encrypted
     QueryEncryption {
+        /// VMGS file path
         #[command(flatten)]
         file_path: FilePathArg,
     },
@@ -269,6 +292,26 @@ enum Options {
     Test {
         #[clap(subcommand)]
         operation: TestOperation,
+    },
+    /// Copy the IGVM file from a dll into file ID 8 of the VMGS file.
+    ///
+    /// The proper key file must be specified to write encrypted data.
+    #[cfg(all(windows, guest_arch = "x86_64"))]
+    CopyIgvmfile {
+        /// VMGS file path
+        #[command(flatten)]
+        file_path: FilePathArg,
+        /// DLL file path to read
+        #[clap(short = 'd', long, alias = "datapath")]
+        data_path: PathBuf,
+        #[command(flatten)]
+        key_path: KeyPathArg,
+        /// Overwrite the VMGS data at `fileid 8`, even if it already exists with nonzero size
+        #[clap(long, alias = "allowoverwrite")]
+        allow_overwrite: bool,
+        /// Resource code. Currently nonconfidential, snp, and tdx are the only values supported.
+        #[clap(short = 'r', long, alias = "resourcecode", value_parser = parse_resource_code)]
+        resource_code: ResourceCode,
     },
 }
 
@@ -296,6 +339,18 @@ fn parse_encryption_algorithm(algorithm: &str) -> Result<EncryptionAlgorithm, &'
     match algorithm {
         "AES_GCM" => Ok(EncryptionAlgorithm::AES_GCM),
         _ => Err("Encryption algorithm not supported"),
+    }
+}
+
+#[cfg(all(windows, guest_arch = "x86_64"))]
+fn parse_resource_code(resource_code: &str) -> Result<ResourceCode, &'static str> {
+    match resource_code {
+        "nonconfidential" => Ok(ResourceCode::NonConfidential),
+        "snp" => Ok(ResourceCode::Snp),
+        "snp_no_hcl" => Ok(ResourceCode::SnpNoHcl),
+        "tdx" => Ok(ResourceCode::Tdx),
+        "tdx_no_hcl" => Ok(ResourceCode::TdxNoHcl),
+        _ => Err("Resource code not supported"),
     }
 }
 
@@ -467,6 +522,23 @@ async fn do_main() -> Result<(), Error> {
         Options::UefiNvram { operation } => uefi_nvram::do_command(operation).await,
         #[cfg(feature = "test_helpers")]
         Options::Test { operation } => test::do_command(operation).await,
+        #[cfg(all(windows, guest_arch = "x86_64"))]
+        Options::CopyIgvmfile {
+            file_path,
+            data_path,
+            key_path,
+            allow_overwrite,
+            resource_code,
+        } => {
+            vmgs_file_copy_igvmfile(
+                file_path.file_path,
+                data_path,
+                key_path.key_path,
+                allow_overwrite,
+                resource_code,
+            )
+            .await
+        }
     }
 }
 
@@ -1100,6 +1172,144 @@ fn vhdfiledisk_open(file: File, open_mode: OpenMode) -> Result<Disk, Error> {
     Ok(disk)
 }
 
+#[cfg(all(windows, guest_arch = "x86_64"))]
+async fn vmgs_file_copy_igvmfile(
+    file_path: impl AsRef<Path>,
+    data_path: impl AsRef<Path>,
+    key_path: Option<impl AsRef<Path>>,
+    allow_overwrite: bool,
+    resource_code: ResourceCode,
+) -> Result<(), Error> {
+    eprintln!("Writing IGVMfile to VMGS");
+
+    let encrypt = key_path.is_some();
+    let mut vmgs = vmgs_file_open(file_path, key_path, OpenMode::ReadWrite).await?;
+
+    write_igvmfile(
+        &mut vmgs,
+        encrypt,
+        allow_overwrite,
+        data_path,
+        resource_code,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(all(windows, guest_arch = "x86_64"))]
+async fn write_igvmfile(
+    vmgs: &mut Vmgs,
+    encrypt: bool,
+    allow_overwrite: bool,
+    data_path: impl AsRef<Path>,
+    resource_code: ResourceCode,
+) -> Result<(), Error> {
+    use std::os::windows::ffi::OsStrExt;
+    eprintln!("Reading IGVMfile from: {}", data_path.as_ref().display());
+
+    // Convert the path to a wide string (UTF-16) for Windows API
+    let dll_path = data_path
+        .as_ref()
+        .as_os_str()
+        .encode_wide()
+        .collect::<Vec<u16>>();
+
+    let bytes = read_igvmfile(dll_path, resource_code).await?;
+
+    vmgs_write(
+        vmgs,
+        FileId::GUEST_FIRMWARE,
+        &bytes,
+        encrypt,
+        allow_overwrite,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(all(windows, guest_arch = "x86_64"))]
+async fn read_igvmfile(dll_path: Vec<u16>, resource_code: ResourceCode) -> Result<Vec<u8>, Error> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use std::slice;
+    use winapi::um::errhandlingapi::GetLastError;
+    use winapi::um::libloaderapi::FindResourceW;
+    use winapi::um::libloaderapi::FreeLibrary;
+    use winapi::um::libloaderapi::LOAD_LIBRARY_AS_DATAFILE;
+    use winapi::um::libloaderapi::LOAD_LIBRARY_AS_IMAGE_RESOURCE;
+    use winapi::um::libloaderapi::LoadLibraryExW;
+    use winapi::um::libloaderapi::LoadResource;
+    use winapi::um::libloaderapi::LockResource;
+    use winapi::um::libloaderapi::SizeofResource;
+    // SAFETY: We are loading a DLL and reading its resources as a datafile or image resource,
+    // which means we will not be executing any of its potentially unsafe functions. We are also
+    // taking precautions to ensure safety by validating all pointers and handling errors appropriately.
+    unsafe {
+        let h_module = LoadLibraryExW(
+            dll_path.as_ptr(),
+            std::ptr::null_mut(),
+            LOAD_LIBRARY_AS_DATAFILE | LOAD_LIBRARY_AS_IMAGE_RESOURCE,
+        );
+        if h_module.is_null() {
+            return Err(Error::UnableToReadIgvmFile(format!(
+                "LoadLibraryExW failed: {}",
+                GetLastError()
+            )));
+        }
+
+        // MAKEINTRESOURCEW equivalent: cast the numeric id into a pointer value
+        let resource_name_ptr = resource_code as usize as *const u16;
+
+        // cast VMFW to correct type
+        let lp_type = OsStr::new("VMFW")
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<u16>>();
+
+        let res_info = FindResourceW(h_module, resource_name_ptr, lp_type.as_ptr());
+        if res_info.is_null() {
+            return Err(Error::UnableToReadIgvmFile(format!(
+                "FindResourceW failed: {}",
+                GetLastError()
+            )));
+        }
+
+        let res_size = SizeofResource(h_module, res_info);
+        if res_size == 0 {
+            return Err(Error::UnableToReadIgvmFile(format!(
+                "SizeofResource failed: {}",
+                GetLastError()
+            )));
+        }
+
+        let res_loaded = LoadResource(h_module, res_info);
+        if res_loaded.is_null() {
+            return Err(Error::UnableToReadIgvmFile(format!(
+                "LoadResource failed: {}",
+                GetLastError()
+            )));
+        }
+
+        let res_ptr = LockResource(res_loaded);
+        if res_ptr.is_null() {
+            return Err(Error::UnableToReadIgvmFile(format!(
+                "LockResource failed: {}",
+                GetLastError()
+            )));
+        }
+
+        let bytes = slice::from_raw_parts(res_ptr as *const u8, res_size as usize).to_vec();
+        eprintln!("Successfully loaded IGVMfile from DLL: {:#?}", dll_path);
+        eprintln!("Read {} bytes", bytes.len());
+
+        FreeLibrary(h_module);
+
+        Ok(bytes)
+    }
+}
+
 fn validate_size(file_size: u64) -> Result<(), Error> {
     const MAX_VMGS_FILE_SIZE: u64 = 4 * ONE_GIGA_BYTE;
 
@@ -1277,6 +1487,35 @@ mod tests {
         assert_eq!(buf_3, read_buf_3);
     }
 
+    #[cfg(all(windows, guest_arch = "x86_64"))]
+    #[async_test]
+    async fn read_write_igvmfile() {
+        use std::os::windows::ffi::OsStrExt;
+        let (_dir, path) = new_path();
+        let data_path = PathBuf::from("C:\\Windows\\System32\\vmfirmwarehcl.dll");
+        let dll_path: Vec<u16> = data_path.as_os_str().encode_wide().chain(once(0)).collect();
+
+        test_vmgs_create(&path, Some(ONE_MEGA_BYTE * 8), false, None)
+            .await
+            .unwrap();
+
+        let mut vmgs = test_vmgs_open(path, OpenMode::ReadWrite, None)
+            .await
+            .unwrap();
+
+        let buf = read_igvmfile(dll_path, ResourceCode::Snp).await.unwrap();
+
+        write_igvmfile(&mut vmgs, false, false, data_path, ResourceCode::Snp)
+            .await
+            .unwrap();
+
+        let read_buf = vmgs_read(&mut vmgs, FileId::GUEST_FIRMWARE, false)
+            .await
+            .unwrap();
+
+        assert_eq!(buf, read_buf);
+    }
+
     #[cfg(with_encryption)]
     #[async_test]
     async fn read_write_encrypted_file() {
@@ -1360,6 +1599,47 @@ mod tests {
             .unwrap();
 
         assert!(read_buf == buf_1);
+    }
+
+    #[cfg(all(windows, with_encryption))]
+    #[async_test]
+    async fn read_write_igvmfile_encrypted() {
+        use std::os::windows::ffi::OsStrExt;
+        // Should be able to read and write IGVMfile to an encrypted VMGS
+        let (_dir, path) = new_path();
+        let data_path = PathBuf::from("C:\\Windows\\System32\\vmfirmwarehcl.dll");
+        let dll_path: Vec<u16> = data_path.as_os_str().encode_wide().collect();
+        let encryption_key = vec![5; 32];
+
+        test_vmgs_create(
+            &path,
+            Some(ONE_MEGA_BYTE * 8),
+            false,
+            Some((EncryptionAlgorithm::AES_GCM, &encryption_key)),
+        )
+        .await
+        .unwrap();
+
+        let mut vmgs = test_vmgs_open(path, OpenMode::ReadWrite, Some(&encryption_key))
+            .await
+            .unwrap();
+
+        let buf = read_igvmfile(dll_path, ResourceCode::Snp).await.unwrap();
+
+        write_igvmfile(&mut vmgs, true, false, data_path, ResourceCode::Snp)
+            .await
+            .unwrap();
+
+        let read_buf = vmgs_read(&mut vmgs, FileId::GUEST_FIRMWARE, true)
+            .await
+            .unwrap();
+
+        assert_eq!(buf, read_buf);
+
+        // try normal write IGVMfile to encrypted VMGS
+        write_igvmfile(&mut vmgs, false, false, data_path, ResourceCode::Snp)
+            .await
+            .unwrap();
     }
 
     #[async_test]


### PR DESCRIPTION
Add tool to VmgsTool to read the IGVMfile from a DLL (passed in as a data file) and write it to VMGS FileId 8 (GUEST_FIRMWARE). To do this pass one of three resource codes (nonconfidential, snp, tdx) into the cmdline tool:

`vmgstool.exe copy-igvmfile --filepath <vmgs file path> --keypath <key file path> --datapath <dll path> --resource-code <code>`