### PR TITLE
[WIP] testing safe operation replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9306,6 +9306,7 @@ dependencies = [
  "guid",
  "hcl_compat_uefi_nvram_storage",
  "hex",
+ "hvlite_pcat_locator",
  "pal_async",
  "serde",
  "serde_json",
@@ -9317,7 +9318,6 @@ dependencies = [
  "uefi_specs",
  "vmgs",
  "vmgs_format",
- "winapi",
 ]
 
 [[package]]

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -22,6 +22,7 @@ disk_vhd1.workspace = true
 uefi_nvram_storage.workspace = true
 guid.workspace = true
 hcl_compat_uefi_nvram_storage.workspace = true
+hvlite_pcat_locator.workspace = true
 pal_async.workspace = true
 uefi_nvram_specvars.workspace = true
 uefi_specs.workspace = true
@@ -38,13 +39,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 ucs2.workspace = true
-
-[target.'cfg(windows)'.dependencies.winapi]
-features = [
-  "libloaderapi",
-  "errhandlingapi",
-]
-workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION
instead of using `unsafe` operations, replace them with the package in openvmm that extracts data from a DLL